### PR TITLE
Update .desktop file to use only official categories

### DIFF
--- a/etc/deploy/linux/qdriverstation.desktop
+++ b/etc/deploy/linux/qdriverstation.desktop
@@ -5,5 +5,5 @@ Exec=qdriverstation
 Terminal=false
 Type=Application
 StartupNotify=true
-Categories=Utility;Network;Joystick;Game;Robots;FRC;
+Categories=Development;Education;Qt;Robotics;Utility;
 Icon=qdriverstation


### PR DESCRIPTION
Official categories being those specified in Appendix A of the Freedesktop.org Desktop Menu Specification v1.0: http://standards.freedesktop.org/menu-spec/menu-spec-1.0.html#category-registry

Current configuration was messing with my Xfce menu a bit.