### PR TITLE
Use "java -jar" to start dashboards on all platforms.

### DIFF
--- a/src/dashboards.cpp
+++ b/src/dashboards.cpp
@@ -36,13 +36,7 @@
 #define PF IS_64_BIT ? "C:/Program Files (x86)" : "C:/Program Files"
 #endif
 
-#if defined Q_OS_WIN
 #define JAVA_OPEN "java -jar"
-#elif defined Q_OS_LINUX
-#define JAVA_OPEN "xdg-open"
-#elif defined Q_OS_MAC
-#define JAVA_OPEN "java -jar"
-#endif
 
 Dashboards::Dashboards()
 {


### PR DESCRIPTION
Pull request to fix #23, unless there is a reason to use `xdg-open`.